### PR TITLE
Disallow dots in beginning and end of usernames

### DIFF
--- a/itp/tests.py
+++ b/itp/tests.py
@@ -542,10 +542,30 @@ class TWPTests(unittest.TestCase):
         self.assertEqual(result.html, 'text <a href="https://instagram.com/username">@username</a>')
         self.assertEqual(result.users, ['username'])
 
-    def test_username_dots(self):
+    def test_username_with_dots(self):
         result = self.parser.parse('text @user.name')
         self.assertEqual(result.html, 'text <a href="https://instagram.com/user.name">@user.name</a>')
         self.assertEqual(result.users, ['user.name'])
+
+    def test_username_ending_with_dots(self):
+        result = self.parser.parse('text @username.')
+        self.assertEqual(result.html, 'text <a href="https://instagram.com/username">@username</a>.')
+        self.assertEqual(result.users, ['username'])
+
+    def test_username_starting_with_dots(self):
+        result = self.parser.parse('text @.username')
+        self.assertEqual(result.html, 'text @.username')
+        self.assertEqual(result.users, [])
+
+    def test_username_with_repeated_dots(self):
+        result = self.parser.parse('text @user..name')
+        self.assertEqual(result.html, 'text <a href="https://instagram.com/user">@user</a>..name')
+        self.assertEqual(result.users, ['user'])
+
+    def test_usernames_with_only_one_character(self):
+        result = self.parser.parse('text @a')
+        self.assertEqual(result.html, 'text <a href="https://instagram.com/a">@a</a>')
+        self.assertEqual(result.users, ['a'])
 
     # Replies
     def test_username_reply_simple(self):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='instagram-text-python',
-    version='2.0.0',
+    version='2.0.1',
     description='Instagram Tweet parser and formatter',
     long_description="Extract @users, #hashtags and URLs (and unwind shortened links) from instagram captions and comments including entity locations, also generate HTML for output. Visit https://github.com/takumihq/instagram-text-python for examples.",
     author='Maintained by Takumi (previously twitter-text-python, which is maintained by Edmond Burnett (previously Ian Ozsvald; originally Ivo Wetzel))',


### PR DESCRIPTION
The usernames are "regexd" as before, including dots in the beginning, end and repeated within the usernames and then parsed in the parser to work with the username conditions regarding dots in usernames.

Usernames can't start with a dot (invalid), can't end with a dot (parse `@foo.` as `foo`) and can't include repeated dots (parse `@foo..bar` as `foo`).

The main part of this PR is the new `_parse_username` function and then tests to test different version of usernames including dots.

All tests run successfully

<img width="804" alt="screen shot 2016-03-16 at 15 43 29" src="https://cloud.githubusercontent.com/assets/3537289/13818470/db1e4cae-eb8d-11e5-8270-753004decc6a.png">
