### PR TITLE
Hashtag parsing in line with Instagram

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,7 @@
 TODO
 ENV/
 dist/
-twitter_text_python.egg-info/
+instagram_text_python.egg-info/
 .tox/
+build/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 instagram-text-python
 ===================
 
-**instagram-text-python** is a Tweet parser and formatter for Python. Extract
+**instagram-text-python** is a caption parser and formatter for Python. Extract
 users, hashtags, URLs and format as HTML for display.
 
 PyPI release: [https://pypi.python.org/pypi/instagram-text-python/](http://pypi.python.org/pypi/instagram-text-python/)

--- a/itp/itp.py
+++ b/itp/itp.py
@@ -49,7 +49,7 @@ REPLY_REGEX = re.compile(r'^(?:' + SPACES + r')*' + AT_SIGNS
                          + r'([a-z0-9_]{1,20}).*', re.IGNORECASE)
 
 # Hashtags
-HASHTAG_EXP = r'(^|[^0-9A-Z&/]+)(#|\uff03)([0-9A-Z_]*[A-Z_]+[%s]*)' % UTF_CHARS
+HASHTAG_EXP = r'(#|\uff03)([0-9A-Z_]*[%s]*)' % UTF_CHARS
 HASHTAG_REGEX = re.compile(HASHTAG_EXP, re.IGNORECASE)
 
 # URLs

--- a/itp/tests.py
+++ b/itp/tests.py
@@ -456,15 +456,19 @@ class TWPTests(unittest.TestCase):
         ))
         self.assertEqual(result.tags, ['hashtag1', 'hashtag2'])
 
-    def test_not_hashtag_number(self):
+    def test_hashtag_only_number(self):
         result = self.parser.parse('text #1234')
-        self.assertEqual(result.html, 'text #1234')
-        self.assertEqual(result.tags, [])
+        self.assertEqual(result.html, 'text <a href="https://instagram.com/explore/tags/1234/">#1234</a>')
+        self.assertEqual(result.tags, ['1234'])
 
-    def test_not_hashtag_text(self):
-        result = self.parser.parse('text#hashtag')
-        self.assertEqual(result.html, 'text#hashtag')
-        self.assertEqual(result.tags, [])
+    def test_hashtags_with_no_spaces_between(self):
+        result = self.parser.parse('test#hashtag1#hashtag2#hashtag3')
+        self.assertEqual(result.html, (
+            'text<a href="https://instagram.com/explore/tags/hashtag1/">#hashtag1</a>'
+            '<a href="https://instagram.com/explore/tags/hashtag2/">#hashtag2</a>'
+            '<a href="https://instagram.com/explore/tags/hashtag2/">#hashtag2</a>'
+        ))
+        self.assertEqual(result.tags, ['hashtag1', 'hashtag2', 'hashtag3'])
 
     def test_hashtag_umlaut(self):
         result = self.parser.parse('text #hash_tagüäö')

--- a/itp/tests.py
+++ b/itp/tests.py
@@ -34,7 +34,7 @@ class TWPTests(unittest.TestCase):
         """Confirm that # in a URL works along with ,"""
         result = self.parser.parse('big url: http://blah.com:8080/path/to/here?p=1&q=abc,def#posn2 #ahashtag')
         self.assertEqual(result.urls, ['http://blah.com:8080/path/to/here?p=1&q=abc,def#posn2'])
-        self.assertEqual(result.tags, ['ahashtag'])
+        self.assertEqual(result.tags, ['posn2', 'ahashtag'])
 
     def test_all_not_allow_amp_without_question(self):
         result = self.parser.parse('Check out: http://www.github.com/test&@username')
@@ -423,11 +423,6 @@ class TWPTests(unittest.TestCase):
         self.assertEqual(result.html, 'text <a href="https://instagram.com/explore/tags/1tag/">#1tag</a>')
         self.assertEqual(result.tags, ['1tag'])
 
-    def test_not_hashtag_escape(self):
-        result = self.parser.parse('&#nbsp;')
-        self.assertEqual(result.html, '&#nbsp;')
-        self.assertEqual(result.tags, [])
-
     def test_hashtag_japanese(self):
         result = self.parser.parse('text #hashtagの')
         self.assertEqual(result.html, 'text <a href="https://instagram.com/explore/tags/hashtag/">#hashtag</a>の')
@@ -462,11 +457,11 @@ class TWPTests(unittest.TestCase):
         self.assertEqual(result.tags, ['1234'])
 
     def test_hashtags_with_no_spaces_between(self):
-        result = self.parser.parse('test#hashtag1#hashtag2#hashtag3')
+        result = self.parser.parse('text#hashtag1#hashtag2#hashtag3')
         self.assertEqual(result.html, (
             'text<a href="https://instagram.com/explore/tags/hashtag1/">#hashtag1</a>'
             '<a href="https://instagram.com/explore/tags/hashtag2/">#hashtag2</a>'
-            '<a href="https://instagram.com/explore/tags/hashtag2/">#hashtag2</a>'
+            '<a href="https://instagram.com/explore/tags/hashtag3/">#hashtag3</a>'
         ))
         self.assertEqual(result.tags, ['hashtag1', 'hashtag2', 'hashtag3'])
 

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,8 @@ from setuptools import setup
 
 setup(
     name='instagram-text-python',
-    version='2.0.1',
-    description='Instagram Tweet parser and formatter',
+    version='2.0.2',
+    description='Instagram caption parser and formatter',
     long_description="Extract @users, #hashtags and URLs (and unwind shortened links) from instagram captions and comments including entity locations, also generate HTML for output. Visit https://github.com/takumihq/instagram-text-python for examples.",
     author='Maintained by Takumi (previously twitter-text-python, which is maintained by Edmond Burnett (previously Ian Ozsvald; originally Ivo Wetzel))',
     author_email='itp@takumihq.com',


### PR DESCRIPTION
## Description

This simplifies the hashtags parsing regex for Instagram texts. Instagram is much more lenient on hashtag parsing than twitter is. The following changes are in this PR:
1. Instagram allows hashtags with `#no#spaces#in#between` while Twitter does not. 
2. URLs on Instagram are not parsed as `a href` urls, so hashtags in urls (`http://example.com/foo#bar`) are just parsed as normal hashtags.
3. Instagram allows hashtags that are only numbers
#### Example screenshot of an Instagram media caption

<img width="307" alt="screen shot 2016-04-05 at 15 17 03" src="https://cloud.githubusercontent.com/assets/3537289/14287219/7bc73c52-fb41-11e5-8172-c630d8bc97c4.png">

I will build and publish a new version on merge.
